### PR TITLE
[FLINK-31951][formats] Reset decoder on Avro deserialization failure

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroDeserializationSchemaDecoderResetTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroDeserializationSchemaDecoderResetTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a deserialization failure does not leave stale bytes in the {@code BinaryDecoder}'s
+ * internal read-ahead buffer, which would corrupt subsequent messages.
+ *
+ * <p>The bug: {@link RegistryAvroDeserializationSchema} reuses a single {@code BinaryDecoder}
+ * across messages. When a decode fails mid-message the decoder's internal buffer retains the
+ * unconsumed bytes from the failed message. The next call to {@code setBuffer()} resets the
+ * underlying stream but does not clear the decoder buffer, so the next message is decoded starting
+ * from those stale bytes and produces wrong results.
+ */
+class RegistryAvroDeserializationSchemaDecoderResetTest {
+
+    private static final Schema SCHEMA =
+            SchemaBuilder.record("Simple")
+                    .namespace("test")
+                    .fields()
+                    .name("id")
+                    .type()
+                    .intType()
+                    .noDefault()
+                    .name("name")
+                    .type()
+                    .stringType()
+                    .noDefault()
+                    .endRecord();
+
+    @Test
+    void testValidMessageDecodedCorrectlyAfterPriorFailure() throws Exception {
+        MockSchemaRegistryClient mockClient = new MockSchemaRegistryClient();
+        int schemaId = mockClient.register("test", SCHEMA);
+
+        ConfluentSchemaRegistryCoder coder = new ConfluentSchemaRegistryCoder(mockClient);
+        RegistryAvroDeserializationSchema<GenericRecord> deserializer =
+                new RegistryAvroDeserializationSchema<>(GenericRecord.class, SCHEMA, () -> coder);
+
+        // Message 1: a malformed Avro payload.
+        //   - 0x02 encodes id=1 (zigzag int, valid)
+        //   - 0x01 encodes string length=-1 (zigzag, invalid — triggers "Malformed data")
+        //   - 10 zero bytes that will linger in the decoder's internal buffer after the failure
+        byte[] badPayload = {0x02, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        byte[] badMessage = confluentMessage(schemaId, badPayload);
+
+        // Deserialization of the malformed message is expected to fail.
+        Exception firstError = null;
+        try {
+            deserializer.deserialize(badMessage);
+        } catch (Exception e) {
+            firstError = e;
+        }
+        assertThat(firstError).as("first (malformed) message must fail").isNotNull();
+
+        // Message 2: a valid Avro payload for the same schema.
+        byte[] goodMessage = confluentMessage(schemaId, encodeRecord(42, "hello"));
+
+        // Without the fix the decoder buffer still holds the 10 zero bytes from message 1.
+        // Those bytes decode as id=0 and name="" instead of id=42 and name="hello".
+        GenericRecord result = deserializer.deserialize(goodMessage);
+
+        assertThat(result.get("id"))
+                .as("id must not be corrupted by stale bytes from the prior failure")
+                .isEqualTo(42);
+        assertThat(result.get("name").toString())
+                .as("name must not be corrupted by stale bytes from the prior failure")
+                .isEqualTo("hello");
+    }
+
+    // -------------------------------------------------------------------------
+    //  Helpers
+    // -------------------------------------------------------------------------
+
+    /** Wraps an Avro binary payload in the Confluent wire format (magic byte + schema_id). */
+    private static byte[] confluentMessage(int schemaId, byte[] avroPayload) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(out);
+        dos.writeByte(0);
+        dos.writeInt(schemaId);
+        dos.flush();
+        out.write(avroPayload);
+        return out.toByteArray();
+    }
+
+    /** Serialises a two-field record using the standard Avro binary encoder. */
+    private static byte[] encodeRecord(int id, String name) throws IOException {
+        GenericRecord record = new GenericData.Record(SCHEMA);
+        record.put("id", id);
+        record.put("name", name);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+        new GenericDatumWriter<GenericRecord>(SCHEMA).write(record, encoder);
+        encoder.flush();
+        return out.toByteArray();
+    }
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -31,6 +31,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
@@ -182,6 +183,23 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
         }
 
         return datumReader.read(null, decoder);
+    }
+
+    /**
+     * Resets the binary decoder after a deserialization failure.
+     *
+     * <p>{@link BinaryDecoder} pre-fetches bytes from the underlying stream into an internal
+     * read-ahead buffer. When a decode fails mid-message the unconsumed bytes remain in that buffer
+     * and corrupt the next message. Reinitialising the decoder discards the stale buffer so the
+     * next call to {@link #deserialize} reads cleanly from the new message bytes.
+     *
+     * <p>This is a no-op for JSON encoding because {@link JsonDecoder} is reconfigured on every
+     * message via {@code configure()}.
+     */
+    void resetDecoder() throws IOException {
+        if (encoding == AvroEncoding.BINARY) {
+            this.decoder = DecoderFactory.get().binaryDecoder(inputStream, (BinaryDecoder) decoder);
+        }
     }
 
     void checkAvroInitialized() throws IOException {

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchema.java
@@ -106,7 +106,14 @@ public class RegistryAvroDeserializationSchema<T> extends AvroDeserializationSch
             ((JsonDecoder) getDecoder()).configure(getInputStream());
         }
 
-        return datumReader.read(null, getDecoder());
+        try {
+            return datumReader.read(null, getDecoder());
+        } catch (IOException | RuntimeException e) {
+            // A failed decode leaves stale bytes in the BinaryDecoder's internal read-ahead buffer.
+            // Reset the decoder so the next message is not corrupted by those bytes.
+            resetDecoder();
+            throw e;
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

`RegistryAvroDeserializationSchema` reuses a single `BinaryDecoder` instance across all messages on a Kafka partition. When `datumReader.read()` fails mid-message (e.g. a malformed payload, a schema mismatch, or an `AvroRuntimeException`), stale bytes remain in the decoder's internal read-ahead buffer. The next call to `datumReader.read()` then starts from those leftover bytes rather than the beginning of the next message, producing corrupt output or cascading failures.

This fix wraps `datumReader.read()` in a try-catch and calls `resetDecoder()` before re-throwing, discarding any pre-fetched bytes and leaving the decoder ready for the next message.


## Brief change log

  - `AvroDeserializationSchema`: add package-private `resetDecoder()` method that reinitialises the `BinaryDecoder` against the existing `inputStream` via `DecoderFactory.get().binaryDecoder(inputStream, decoder)`; no-op for JSON encoding
  - `RegistryAvroDeserializationSchema`: wrap `datumReader.read()` in a try-catch on `IOException | RuntimeException`; call `resetDecoder()` before re-throwing so that a failed decode does not corrupt the bytes available to the next message
  - Add `RegistryAvroDeserializationSchemaDecoderResetTest`: serialises a malformed message followed by a valid one and asserts the valid message deserialises correctly after the failed decode


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

  - Added `RegistryAvroDeserializationSchemaDecoderResetTest` which writes a Confluent Schema Registry framed message with a garbage Avro payload (triggering an `AvroRuntimeException` mid-decode), followed by a correctly encoded message, then deserialises both in sequence and asserts that the second message produces the expected field values (`id=42`, `name="hello"`). Without the fix, the second decode reads from the stale bytes left by the first failure and also throws.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (`resetDecoder()` is package-private; no public method signatures are changed)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes; `datumReader.read()` is now wrapped in a try-catch on every deserialization call. In the happy path (no exception thrown) this has negligible overhead in modern JVMs
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
